### PR TITLE
fix: improve the performance on tcell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Upload Go test results
+name: Go tests
 
 on: [push]
 
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.19' ]
+        go-version: [ '1.20' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/at-ishikawa/go-shell
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/mock v1.6.0

--- a/internal/completion/tcell_test.go
+++ b/internal/completion/tcell_test.go
@@ -170,7 +170,7 @@ func TestTcellCompletion_complete(t *testing.T) {
 			keyEvents: func(screen tcell.SimulationScreen) {
 				screen.InjectKey(tcell.KeyTab, emptyRune, tcell.ModNone)
 			},
-			wantErr: errors.New("error"),
+			wantErr: errors.Join(errors.New("error")),
 		},
 		{
 			name: "return nil when no matches",


### PR DESCRIPTION
https://github.com/at-ishikawa/go-shell/issues/8

* Stop running a rendering routine for all inputs. It'll be buffered until the last rendering routine ends
* Run a preview command on the background. And cancel the command if there is another render starts